### PR TITLE
Remove hash comments from Python scripts

### DIFF
--- a/poop_system.py
+++ b/poop_system.py
@@ -302,4 +302,3 @@ class PoopSystem:
             removed_poop = self.poops.pop(index)
             return True
         return False
-    


### PR DESCRIPTION
Iterated through all .py files and removed #-style comments.